### PR TITLE
Use env placeholders for contact links

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,19 @@ I’m building a lightweight workflow to generate **targeted resumes and cover l
 
 - This MVP follows my process flow: fit assessment, gap spotting, drafting, and final review/export.
 - I drew on prior ATS experience to keep outputs competitive yet honest.
+
+## Contact data configuration
+
+- Sensitive contact fields inside `work_history_v_1_0_1.xml` use `env:` placeholders (for example, `env:CONTACT_EMAIL`) instead of storing the literal values in Git.
+- When a generator or other tool needs to output a resume or cover letter, resolve each placeholder by reading the environment variable named after the suffix (e.g., `CONTACT_EMAIL`).
+- Populate those environment variables through a secure channel such as your workstation keychain, a `.env` file that is excluded from source control, or a secrets manager/injected CI/CD variable.
+- Example `.env` snippet for local runs:
+
+  ```env
+  CONTACT_EMAIL="matt@example.com"
+  CONTACT_PHONE="+64 22 000 0000"
+  CONTACT_LINKEDIN="https://www.linkedin.com/in/example"
+  CONTACT_GITHUB="https://github.com/example"
+  ```
+
+- Do **not** commit the real values; ensure your tooling loads them at runtime before templating HTML/PDF outputs.

--- a/work_history_v_1_0_1.xml
+++ b/work_history_v_1_0_1.xml
@@ -4,10 +4,10 @@
     <name>Matt Millar</name>
     <headline>Technical Business Analyst | Data &amp; Insights</headline>
     <summary>Delivery-centric Technical BA who clarified needs, ran workshops, and turned requirements into tidy delivery and plain-English outcomes. Strong with Excel/Power BI and documentation; built depth in stakeholder comms and BAU support.</summary>
-    <links email="matt@mattmillar.co.nz"
-           phone="+64 22 459 6484"
-           linkedin="https://www.linkedin.com/in/matt-millar-3a4892121/"
-           github="https://github.com/mkm-cdnz/" />
+    <links email="env:CONTACT_EMAIL"
+           phone="env:CONTACT_PHONE"
+           linkedin="env:CONTACT_LINKEDIN"
+           github="env:CONTACT_GITHUB" />
   </profile>
 
   <work_history>


### PR DESCRIPTION
## Summary
- replace direct contact attributes in `work_history_v_1_0_1.xml` with environment placeholders
- document the runtime contact configuration approach in the README

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cd66bf8f28832e98f501558c63e34c